### PR TITLE
Convert id to String for Jekyll:URL (Jekyll 3.8.3)

### DIFF
--- a/lib/jekyll/strapi/site.rb
+++ b/lib/jekyll/strapi/site.rb
@@ -28,7 +28,7 @@ module Jekyll
       url = Jekyll::URL.new(
         :template => @config['strapi']['collections'][collection]['permalink'],
         :placeholders => {
-          :id => document.id,
+          :id => document.id.to_s,
           :uid => document.uid,
           :slug => document.slug,
           :type => document.type


### PR DESCRIPTION
If the id integer then the Addressable::URI.encode method fail with an error:
"Liquid Exception: Can't convert Integer into String. in /_layouts/home.html"
in Jekyll:URL.escape_path