### PR TITLE
added support for SSL strapi servers (https)

### DIFF
--- a/lib/jekyll/strapi/collection.rb
+++ b/lib/jekyll/strapi/collection.rb
@@ -19,15 +19,11 @@ module Jekyll
 
       def each
         # Initialize the HTTP query
-        endpoint = URI.parse(@site.endpoint)
-        uri = URI::HTTP.build({:host => endpoint.host,
-                               :port => endpoint.port,
-                               :path => "/#{@config['type'] || @collection_name}",
-                               :query => "_limit=10000"})
-
+        path = "/#{@config['type'] || @collection_name}?_limit=10000"
+        uri = URI("#{@site.endpoint}#{path}")
+        Jekyll.logger.info "Jekyll Strapi:", "Fetching entries from #{uri}"
         # Get entries
         response = Net::HTTP.get_response(uri)
-
         # Check response code
         if response.code == "200"
           result = JSON.parse(response.body, object_class: OpenStruct)


### PR DESCRIPTION
the current code does not support https because of the way the URI object is constructed. after a short research, I stumbled upon https://stackoverflow.com/questions/5786779/using-nethttp-get-for-an-https-url where the problem is described. I have basically changed the code inspired by this SO article. I have tested this code on our production env.

would be great if someone reviews this code and merges it into master