### PR TITLE
Upgrade version of Jekyll dep to >= 4

### DIFF
--- a/jekyll-strapi.gemspec
+++ b/jekyll-strapi.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     A Jekyll plugin for retrieving content from a Strapi API
   DESC
 
-  spec.add_runtime_dependency("jekyll", "~> 3")
+  spec.add_runtime_dependency("jekyll", ">= 4")
   spec.add_runtime_dependency("http", "~> 3.2")
   spec.add_runtime_dependency("json", "~> 2.1")
 end


### PR DESCRIPTION
Just a little version upgrade for the gem to handle Jekyll >= 4