### PR TITLE
add support for api v4 collection

### DIFF
--- a/lib/jekyll/strapi/collection.rb
+++ b/lib/jekyll/strapi/collection.rb
@@ -34,14 +34,26 @@ module Jekyll
         end
 
         # Add necessary properties
-        result.each do |document|
-          document.type = collection_name
-          document.collection = collection_name
-          document.id ||= document._id
-          document.url = @site.strapi_link_resolver(collection_name, document)
-        end
+        case @config["api_version"]
+        when "v4"
+          result.data.each do |document|
+            document.type = collection_name
+            document.collection = collection_name
+            document.id ||= document._id
+            document.url = @site.strapi_link_resolver(collection_name, document)
+          end
 
-        result.each {|x| yield(x)}
+          result.data.each {|x| yield(x)}
+        else
+          result.each do |document|
+            document.type = collection_name
+            document.collection = collection_name
+            document.id ||= document._id
+            document.url = @site.strapi_link_resolver(collection_name, document)
+          end
+
+          result.each {|x| yield(x)}
+        end
       end
     end
   end

--- a/lib/jekyll/strapi/collection.rb
+++ b/lib/jekyll/strapi/collection.rb
@@ -17,9 +17,12 @@ module Jekyll
         @config['output'] || false
       end
 
+      def path
+        "/#{@config['type'] || @collection_name}?_limit=10000"
+      end
+
       def each
         # Initialize the HTTP query
-        path = "/#{@config['type'] || @collection_name}?_limit=10000"
         uri = URI("#{@site.endpoint}#{path}")
         Jekyll.logger.info "Jekyll Strapi:", "Fetching entries from #{uri}"
         # Get entries

--- a/lib/jekyll/strapi/site.rb
+++ b/lib/jekyll/strapi/site.rb
@@ -7,7 +7,7 @@ module Jekyll
 
     def strapi_collections
       return Array.new unless has_strapi_collections?
-      @strapi_collections ||= Hash[@config['strapi']['collections'].map {|name, config| [name, Strapi::StrapiCollection.new(self, name, config)]}]
+      @strapi_collections ||= Hash[@config['strapi']['collections'].map {|name, config| [name, Strapi::StrapiCollection.new(self, name, config.merge("api_version" => @config['strapi']['api_version']))]} ]
     end
 
     def has_strapi?


### PR DESCRIPTION
The response for api v4 collection is different than from the previous versions. I've made a **temporary** fast fix, but I think this code should be streamlined. 

Current changes:
- possible to set api version in config
- assign api version to collection config data
- if v4 is selected - render by data