### PR TITLE
make jekyll-strapi plugin work with strapi-v4

### DIFF
--- a/lib/jekyll/strapi/collection.rb
+++ b/lib/jekyll/strapi/collection.rb
@@ -34,14 +34,14 @@ module Jekyll
         end
 
         # Add necessary properties
-        result.each do |document|
+        result.data.each do |document|
           document.type = collection_name
           document.collection = collection_name
           document.id ||= document._id
           document.url = @site.strapi_link_resolver(collection_name, document)
         end
 
-        result.each {|x| yield(x)}
+        result.data.each {|x| yield(x)}
       end
     end
   end

--- a/lib/jekyll/strapi/collection.rb
+++ b/lib/jekyll/strapi/collection.rb
@@ -19,7 +19,7 @@ module Jekyll
 
       def each
         # Initialize the HTTP query
-        path = "/#{@config['type'] || @collection_name}?_limit=10000"
+        path = "/#{@config['type'] || @collection_name}?populate=*&_limit=10000"
         uri = URI("#{@site.endpoint}#{path}")
         Jekyll.logger.info "Jekyll Strapi:", "Fetching entries from #{uri}"
         # Get entries

--- a/lib/jekyll/strapi/collection.rb
+++ b/lib/jekyll/strapi/collection.rb
@@ -19,7 +19,7 @@ module Jekyll
 
       def each
         # Initialize the HTTP query
-        path = "/#{@config['type'] || @collection_name}?populate=*&_limit=10000"
+        path = "/#{@config['type'] || @collection_name}?_limit=10000"
         uri = URI("#{@site.endpoint}#{path}")
         Jekyll.logger.info "Jekyll Strapi:", "Fetching entries from #{uri}"
         # Get entries

--- a/lib/jekyll/strapi/generator.rb
+++ b/lib/jekyll/strapi/generator.rb
@@ -8,7 +8,7 @@ module Jekyll
         site.strapi_collections.each do |collection_name, collection|
           if collection.generate?
             collection.each do |document|
-              site.pages << StrapiPage.new(site, site.source, document.attributes, collection)
+              site.pages << StrapiPage.new(site, site.source, document, collection)
             end
           end
         end
@@ -38,7 +38,7 @@ module Jekyll
       end
 
       def url_placeholders
-        requiredValues = @document.to_h.select {|k, v|
+        requiredValues = @document.attributes.to_h.select {|k, v|
           v.class == String and @collection.config['permalink'].include? k.to_s
         }
 

--- a/lib/jekyll/strapi/generator.rb
+++ b/lib/jekyll/strapi/generator.rb
@@ -8,7 +8,7 @@ module Jekyll
         site.strapi_collections.each do |collection_name, collection|
           if collection.generate?
             collection.each do |document|
-              site.pages << StrapiPage.new(site, site.source, document, collection)
+              site.pages << StrapiPage.new(site, site.source, document.attributes, collection)
             end
           end
         end

--- a/lib/jekyll/strapi/site.rb
+++ b/lib/jekyll/strapi/site.rb
@@ -30,8 +30,12 @@ module Jekyll
         :placeholders => {
           :id => document.id.to_s,
           :uid => document.uid,
-          :slug => document.slug,
-          :type => document.type
+          :slug => document.attributes.slug,
+          :type => document.type,
+          :date => document.attributes.date,
+          :title => document.attributes.title
+          # look inside jekyll _data folder
+          #:title => document.data,
         }
       )
 


### PR DESCRIPTION
this update allows strapi v4 api to work with jekyll. 

:raised_hands: 