### PR TITLE
Allow Strapi endpoint to be set by environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ plugins:
 ```yaml
 strapi:
     # Your API endpoint (optional, default to http://localhost:1337)
+    # Can be overridden (or set) by the STRAPI_ENDPOINT environment variable.
     endpoint: http://localhost:1337
     # Collections, key is used to access in the strapi.collections
     # template variable

--- a/lib/jekyll/strapi4/site.rb
+++ b/lib/jekyll/strapi4/site.rb
@@ -21,7 +21,7 @@ module Jekyll
     end
 
     def endpoint
-      has_strapi? and @config['strapi']['endpoint'] or "http://localhost:1337"
+      has_strapi? and ENV['STRAPI_ENDPOINT'] or @config['strapi']['endpoint'] or "http://localhost:1337"
     end
 
     def strapi_link_resolver(collection = nil, document = nil)


### PR DESCRIPTION
This PR adds the option for the Strapi endpoint to be set by an environment variable, `STRAPI_ENDPOINT`. If set, the environment variable overrides the value in `_config.yml`.

One use case for this is to change your Jekyll site to point to a local development version of Strapi without needing to change the hard-coded production URL in `_config.yml`. Alternatively, a user could remove the endpoint from the config file and always rely on an environment variable supplied by each build environment.