### PR TITLE
Add basic strapi5 compatibility option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A: Every project deserves to have the cute deer as a logo.
 
 * Support for Strapi 4
 * Authentication
+* (Basic) Strapi5 Compatability
 * Permalinks
 * Caching and collecting assets from Strapi
 * Added UnitTests
@@ -38,6 +39,8 @@ plugins:
 strapi:
     # Your API endpoint (optional, default to http://localhost:1337)
     endpoint: http://localhost:1337
+    # Strapi5 compatability (optional, default false)
+    v5compat: true
     # Collections, key is used to access in the strapi.collections
     # template variable
     collections:
@@ -77,6 +80,12 @@ This works for the following collection *Photo* in Strapi:
 To access non Public collections (and by default all Strapi collections are non Public) you must to generate a token inside your strapi instance and set it as enviromental variable `STRAPI_TOKEN`.
 
 It is recommended that you will use new Content API tokens for this task: https://strapi.io/blog/a-beginners-guide-to-authentication-and-authorization-in-strapi
+
+###  (Basic) Strapi5 Compatability
+
+Strapi5 introduced breaking changes to the response format as well as the way published documents are accessed. (https://docs.strapi.io/dev-docs/migration/v4-to-v5/breaking-changes/)
+
+In order to use this plugin with strapi5, make sure to set `v5compat: true` in your `_config.yml`.
 
 ## Usage
 

--- a/lib/jekyll/strapi4/collection.rb
+++ b/lib/jekyll/strapi4/collection.rb
@@ -30,14 +30,14 @@ module Jekyll
         # https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.html#pagination-by-page
         uri = URI("#{@site.endpoint}/api/#{endpoint}#{path_params}")
         Jekyll.logger.debug "StrapiCollection get_document:" "#{collection_name} #{uri}"
-        response = strapi_request(uri)
+        response = strapi_request(uri, @site.v5compat)
         response.data
       end
 
       def get_document(did)
         uri_document = URI("#{@site.endpoint}/api/#{endpoint}/#{did}?populate=#{populate}")
         Jekyll.logger.debug "StrapiCollection iterating uri_document:" "#{uri_document}"
-        strapi_request(uri_document)
+        strapi_request(uri_document, @site.v5compat)
         # document
       end
 
@@ -51,7 +51,12 @@ module Jekyll
           if single_request?
             document.strapi_attributes = document.attributes
           else
-            document_response = get_document(document.id)
+            # use documentId if we are running against strapi5 https://docs.strapi.io/dev-docs/migration/v4-to-v5/breaking-changes/use-document-id
+            if @site.v5compat
+              document_response = get_document(document.documentId)
+            else
+              document_response = get_document(document.id)
+            end
             # We will keep all the attributes in strapi_attributes
             document.strapi_attributes = document_response['data']["attributes"]
           end

--- a/lib/jekyll/strapi4/site.rb
+++ b/lib/jekyll/strapi4/site.rb
@@ -23,6 +23,10 @@ module Jekyll
     def endpoint
       has_strapi? and @config['strapi']['endpoint'] or "http://localhost:1337"
     end
+    
+    def v5compat
+      has_strapi? and @config['strapi']['v5compat'] or false
+    end
 
     def strapi_link_resolver(collection = nil, document = nil)
       return "/" unless collection != nil and @config['strapi']['collections'][collection]['permalink'] != nil

--- a/lib/jekyll/strapi4/strapihttp.rb
+++ b/lib/jekyll/strapi4/strapihttp.rb
@@ -2,7 +2,7 @@
 # This is a helper method to authenticate during getting data from Strapi instance.
 require "json"
 
-def strapi_request(url)
+def strapi_request(url, v5compat = false)
     uri = URI(url)
     req = Net::HTTP::Get.new(uri)
     strapi_token = ENV['STRAPI_TOKEN']
@@ -14,6 +14,10 @@ def strapi_request(url)
             'Authorization'=>"Bearer #{strapi_token}"
         }
         req['Authorization'] = "Bearer #{strapi_token}"
+    end
+    # Add header to adjust response structure https://docs.strapi.io/dev-docs/migration/v4-to-v5/breaking-changes/new-response-format
+    if v5compat
+        headers['Strapi-Response-Format'] = "v4"
     end
     Jekyll.logger.info "Jekyll StrapiHTTP:", "Fetching entries from #{uri} using headers: #{headers.keys}"
     response = Net::HTTP.get_response(uri, headers)

--- a/lib/jekyll/strapi4/version.rb
+++ b/lib/jekyll/strapi4/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Strapi
-    VERSION = "1.0.12"
+    VERSION = "1.0.13"
   end
 end


### PR DESCRIPTION
This PR adds a strapi5 compatibility option to address some breaking changes made in the API.
This has been tested with a fairly basic strapi5 setup, so not all breaking changes in v5 may be covered.

- Added property `v5compat` as site option
- Add HTTP header `Strapi-Response-Format: v4` to requests if v5compat is true (https://docs.strapi.io/dev-docs/migration/v4-to-v5/breaking-changes/new-response-format)
- Use `document.documentId` instead of `document.id` when making requests if v5compat is true (https://docs.strapi.io/dev-docs/migration/v4-to-v5/breaking-changes/use-document-id)
- Added information to README.md
- Bumped version